### PR TITLE
fix: update tanstack router devtools version

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@storybook/test": "^8.2.8",
     "@tanstack/react-query-devtools": "^5.51.23",
     "@tanstack/react-table-devtools": "^8.20.1",
-    "@tanstack/router-devtools": "1.47.1",
+    "@tanstack/router-devtools": "^1.47.1",
     "@tanstack/router-plugin": "^1.47.0",
     "@testing-library/jest-dom": "^6.4.8",
     "@testing-library/react": "^16.0.0",


### PR DESCRIPTION
**Understanding the Problem**

The original error message pointed to a missing dependency, `@babel/plugin-syntax-jsx`, which is crucial for handling JSX syntax. This was misleading, as the root cause was likely an incompatibility between the specific version of `@tanstack/router-devtools` (1.47.1) and another dependency in your project.

**How the Fix Worked**

Updating to `@tanstack/router-devtools": "^1.47.1"` likely resolved the issue due to one of the following reasons:

1. **Peer Dependency Resolution:** The newer version of `@tanstack/router-devtools` may have adjusted its peer dependency requirements, ensuring compatibility with the version of `@babel/plugin-syntax-jsx` already present in your project.

2. **Bug Fix:** It's also possible that version 1.47.1 of `@tanstack/router-devtools` contained a bug that caused an incorrect dependency resolution, and this bug was fixed in subsequent releases.
