### PR TITLE
style(prettier): update prettier format command in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "type": "module",
   "scripts": {
     "setup": "git init && npx husky init && npx playwright install && shx rm .husky/pre-commit",
-    "format": "prettier src/**/*.{ts,tsx} --write",
+    "format": "prettier \"src/**/*.{ts,tsx}\" --write",
     "lint": "eslint --max-warnings 0",
     "lint:fix": "eslint --max-warnings 0 --fix",
     "dev": "vite",


### PR DESCRIPTION
The CLI: `pnpm format` will run `prettier src/**/*.{ts,tsx} --write`
- The command doesn't use quotation marks. This works fine in most Unix-like shells (bash, zsh, etc.) but might need quotes in some environments

If I run with `prettier src/**/*.{ts,tsx} --write`, the output will be: 
<img width="718" alt="Screenshot 2024-09-24 at 15 31 38" src="https://github.com/user-attachments/assets/e1137acf-1bb2-4327-aed9-4e55ff4dcdc9">

I add the `\"` around the `src/**/*.{ts,tsx}` 
This is typically necessary in some shell environments (like Windows Command Prompt) to prevent the shell from expanding the glob pattern.
Output after the change:
<img width="728" alt="Screenshot 2024-09-24 at 15 31 48" src="https://github.com/user-attachments/assets/443bcbee-2e16-4821-8172-61fb8092a2cd">

