### PR TITLE
docs: add Deploy on Hostinger button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Vite React Boilerplate
 
+[![Deploy on Hostinger](https://assets.hostinger.com/vps/deploy.svg)](https://www.hostinger.com/web-apps-hosting)
+
 ![](/public/vite-react-boilerplate.png)
 
 Everything you need to kick off your next Vite + React web app!


### PR DESCRIPTION
This PR adds a "Deploy on Hostinger" button to the README for one-click hosting discovery.

- Button points to: https://www.hostinger.com/web-apps-hosting
- Only README was changed.